### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,10 @@
 name=BraccioRobot
 version=1.0.0
-author=Stefan Strömberg
-maintainer=Stefan Strömberg <stefangs@nethome.nu>
+author=Stefan StrÃ¶mberg
+maintainer=Stefan StrÃ¶mberg <stefangs@nethome.nu>
 sentence=Braccio Robot controller API.
 paragraph=Designed for TinkerKit Braccio.
 category=Device Control
 url=http://www.arduino.org/learning/reference/Braccio
 architectures=avr, samd, sam
+depends=Servo


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format